### PR TITLE
Fix `ExtendsFromModAttribute` Bug

### DIFF
--- a/AnimLib/Internal/AnimLoader.cs
+++ b/AnimLib/Internal/AnimLoader.cs
@@ -8,6 +8,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.Exceptions;
 
 namespace AnimLib.Internal {
@@ -95,7 +96,7 @@ namespace AnimLib.Internal {
 
       // Collect all instantiatable types.
       // Collect only animation types if the mod is not being run on a server
-      types = (from t in mod.Code.GetTypes()
+      types = (from t in AssemblyManager.GetLoadableTypes(mod.Code)
         where !t.IsAbstract && !t.IsGenericType &&
               (UseAnimations && t.IsSubclassOf(typeof(AnimationSource)) ||
                UseAnimations && t.IsSubclassOf(typeof(AnimationController)) ||


### PR DESCRIPTION
* Fixed AnimLib throwing exceptions when loading a mod that uses `ExtendsFromModAttribute`.